### PR TITLE
fix: correct metting note path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ This meeting is for Screwdriver cluster administrators and developers to share o
 
 ### Archives
 
-Meetings notes to be archived [here.](./docs/archive) 
+Meetings notes to be archived [here.](./meetings) 

--- a/docs/archive/README.md
+++ b/docs/archive/README.md
@@ -1,1 +1,0 @@
-Screwdriver community meeting notes will be archived in this folder.


### PR DESCRIPTION
## Context

Location of archive was originally in a different place, but since we started under `meetings` lets continue there.


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
